### PR TITLE
Updates to work with November 2022 archives

### DIFF
--- a/analyse.php
+++ b/analyse.php
@@ -76,7 +76,7 @@ foreach (getJSON("following.js", $argv[1]) as $follow) {
 // Tweets file may be split into several parts (tweet.js, tweet-part1.js, etc)
 $handle = opendir($argv[1]);
 while (FALSE !== ($filename = readdir($handle))) {
-    if (0 === strpos($filename, "tweet")) {
+    if (0 === strpos($filename, "tweet") && ".js" === substr($filename, -3)) {
         foreach (getJSON($filename, $argv[1]) as $tweet) {
             $tweet = $tweet->tweet;
             $reply_to = $tweet->in_reply_to_user_id_str ?? NULL;


### PR DESCRIPTION
There's a small issue where the script won't run on the latest version of the archive since uploaded media are now stored in tweets_media. I've added an extra check that the file name also ends with the .js extension.